### PR TITLE
spi整合Spring注解开发

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,18 @@
             <artifactId>junit</artifactId>
             <version>4.12</version>
         </dependency>
+        <!-- Spring -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>5.2.6.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>5.2.6.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/zeusRpc-core/pom.xml
+++ b/zeusRpc-core/pom.xml
@@ -11,5 +11,12 @@
 
     <artifactId>zeusRpc-core</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>group.zeus</groupId>
+            <artifactId>zeusRpc-spi</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/zeusRpc-spi/src/main/java/group/zeus/spi/ExtensionLoader.java
+++ b/zeusRpc-spi/src/main/java/group/zeus/spi/ExtensionLoader.java
@@ -250,7 +250,7 @@ public class ExtensionLoader<T> {
         if (exceptions.containsKey(name.toLowerCase())) {
             return exceptions.get(name.toLowerCase());
         }
-        StringBuilder buf = new StringBuilder("No such extension " + type.getName() + "by name " + name);
+        StringBuilder buf = new StringBuilder("No such extension " + type.getName() + " by name " + name);
 
         int i = 1;
         for (Map.Entry<String, IllegalStateException> entry : exceptions.entrySet()) {

--- a/zeusRpc-spi/src/test/java/group/zeus/spi/HelloWorldImpl.java
+++ b/zeusRpc-spi/src/test/java/group/zeus/spi/HelloWorldImpl.java
@@ -7,6 +7,6 @@ package group.zeus.spi;
 public class HelloWorldImpl implements HelloWorld{
     @Override
     public void sayHello() {
-        System.out.println("Hello, I'm on behalf of one extension implementation of Interface HelloWord");
+        System.out.println("Hello, I'm on behalf of one extension implementation of Interface HelloWord, named `hello1`");
     }
 }

--- a/zeusRpc-spi/src/test/java/group/zeus/spi/HelloWorldImpl2.java
+++ b/zeusRpc-spi/src/test/java/group/zeus/spi/HelloWorldImpl2.java
@@ -1,0 +1,12 @@
+package group.zeus.spi;
+
+/**
+ * @Author: maodazhan
+ * @Date: 2020/10/28 18:17
+ */
+public class HelloWorldImpl2 implements HelloWorld{
+    @Override
+    public void sayHello() {
+        System.out.println("Hello, I'm on behalf of one extension implementation of Interface HelloWord, named `hello2`");
+    }
+}

--- a/zeusRpc-spi/src/test/java/group/zeus/spi/SpiTests.java
+++ b/zeusRpc-spi/src/test/java/group/zeus/spi/SpiTests.java
@@ -2,6 +2,7 @@ package group.zeus.spi;
 
 
 import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
  * @Author: maodazhan
@@ -24,6 +25,12 @@ public class SpiTests {
         // get default extension impl instance
         HelloWorld instance = SpiFactory.getExtension(HelloWorld.class, "default");
         instance.sayHello();
+    }
+
+    @Test
+    public void testSpringSPI(){
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext(TestSpiConfiguration.class);
+        applicationContext.getBean(HelloWorld.class).sayHello();
     }
 
 }

--- a/zeusRpc-spi/src/test/java/group/zeus/spi/TestSpiConfiguration.java
+++ b/zeusRpc-spi/src/test/java/group/zeus/spi/TestSpiConfiguration.java
@@ -1,0 +1,26 @@
+package group.zeus.spi;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * @Author: maodazhan
+ * @Date: 2020/10/28 16:45
+ */
+@Configuration
+@PropertySource(value={"classpath:/application.properties"})
+public class TestSpiConfiguration {
+
+    @Value("${zeusRpc.helloWorld}")
+    private String configured_extension;
+
+    @Bean
+    public  HelloWorld getHelloWorld(){
+        if (!configured_extension.equals("${zeusRpc.helloWorld}"))
+            return SpiFactory.getExtension(HelloWorld.class, configured_extension);
+        else
+            return SpiFactory.getExtension(HelloWorld.class, "default");
+    }
+}

--- a/zeusRpc-spi/src/test/resources/META-INF/SPI/group.zeus.spi.HelloWorld
+++ b/zeusRpc-spi/src/test/resources/META-INF/SPI/group.zeus.spi.HelloWorld
@@ -1,1 +1,2 @@
 hello1 = group.zeus.spi.HelloWorldImpl
+hello2 = group.zeus.spi.HelloWorldImpl2

--- a/zeusRpc-spi/src/test/resources/application.properties
+++ b/zeusRpc-spi/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+zeusRpc.helloWorld=hello2


### PR DESCRIPTION
## done
spi和Spring都有bean容器的功能，在本项目中spi容器通过扩展创建的bean最后移交Spring管理，
可以说Spring是外部容器，SPI是RPC各个核心组件接口自定义实现的内部容器
目前已经通过一个HelloWorld接口，以及两个扩展实现HelloWorldImpl和HelloWorld2测试完成Spring整合spi的功能
## todo 
后续将用spi和spring整合的方案用于自定义RPC组件扩展注册到Spring容器。